### PR TITLE
Create generic `/predict` endpoint to match DS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,27 @@ The GET `/api/year` endpoint supports the following query parameters:
 
 | Method | Endpoint                            | Body             | Description                                      |
 | ------ | ----------------------------------- | ---------------- | ------------------------------------------------ |
+| POST   | `/api/predict/:id`                  | None             | Returns a predictions for the car                |
 | POST   | `/api/predict/carbon_emissions/:id` | None             | Returns a prediction for CO2 generated           |
-| POST   | `/api/predict/price/:id`            | None             | Returns a prediction for the price of the car    |
 | POST   | `/api/predict/carbon_emissions2`    | Array of car ids | Returns an array of CO2 predictions, limit of 10 |
+
+Format returned from POST `/api/predict/:id`:
+
+```
+{
+  "id": 15590,
+  "make": "Acura",
+  "model": "NSX",
+  "year": 2000,
+  "predicted_price": 2873.39,
+  "fuel_cost": 12500,
+  "maintenance_cost": 5000,
+  "five_year_cost_to_own": 20373.39,
+  "co2_five_year_kgs": 37029.17,
+  "number_of_trees_to_offset": 340
+}
+
+```
 
 Format of POST `/api/predict/carbon_emissions/:id`:
 
@@ -94,18 +112,6 @@ Format of POST `/api/predict/carbon_emissions/:id`:
   "model": "X",
   "year": 2018,
   "predicted_carbon_emissions": 3213.0
-}
-```
-
-Format of POST `/api/predict/price/:id`:
-
-```
-{
-  "id": 1,
-  "make": "Tesla",
-  "model": "X",
-  "year": 2018,
-  "predicted_price": 26000
 }
 ```
 

--- a/predict/model.js
+++ b/predict/model.js
@@ -54,12 +54,22 @@ function requestPrediction(endpoint, car) {
     .then((prediction) => {
       return {
         ok: {
+          // Details on the car
           id: car.id,
           make: car.make,
           model: car.model,
           year: car.year,
+
+          // Predictions for the car
           predicted_carbon_emissions: prediction.data.predicted_co2_sql,
-          predicted_price: prediction.data.predicted_price,
+          predicted_price: prediction.data.car_price_prediction,
+          fuel_cost: prediction.data.fuel_cost,
+          maintenance_cost: prediction.data.maintenance_cost,
+          five_year_cost_to_own: prediction.data.five_year_cost_to_own,
+          co2_five_year_kgs: prediction.data.co2_five_year_kgs,
+          number_of_trees_to_offset: prediction.data.number_of_trees_to_offset,
+
+          // Return status
           status: 200,
         },
       };

--- a/predict/router.js
+++ b/predict/router.js
@@ -7,9 +7,6 @@ const { getPredictionForCar, getSinglePrediction } = require('./model');
 router.post("/carbon_emissions/:id", getSinglePrediction("carbon_emissions2"));
 
 //POST /api/predict/carbon_emissions
-router.post("/price/:id", getSinglePrediction("price"));
-
-//POST /api/predict/carbon_emissions
 router.post("/carbon_emissions2", async (req, res) => {
   if (!req.body || !Array.isArray(req.body)) {
     console.log(req.body);
@@ -39,5 +36,8 @@ router.post("/carbon_emissions2", async (req, res) => {
   res.status(200).json(res_data);
 });
 
+
+//POST /api/predict/carbon_emissions
+router.post("/:id", getSinglePrediction("predict"));
 
 module.exports = router;

--- a/predict/router.spec.js
+++ b/predict/router.spec.js
@@ -55,28 +55,33 @@ describe("POST /api/predict/carbon_emissions2", () => {
     })
 })
 
-describe("POST /api/predict/price", () => {
-    it("add car ID", async () => {
+describe("POST /api/predict", () => {
+    it("should return a prediction for the car price", async () => {
         const data = {
-            predicted_price: 300,
+          car_price_prediction: 2873.39,
+          fuel_cost: 12500,
+          maintenance_cost: 5000,
+          five_year_cost_to_own: 20373.39,
+          co2_five_year_kgs: 37029.17,
+          number_of_trees_to_offset: 340
         };
 
         mockAxios.post.mockImplementationOnce(() => Promise.resolve({ status: 200, data }));
         const res = await request(server)
-            .post("/api/predict/price/1")
+            .post("/api/predict/1")
         expect(res.status).toBe(200);
-        expect(res.body.predicted_price).toBe(data.predicted_price);
+        expect(res.body.predicted_price).toBe(data.car_price_prediction);
     })
 
     it("POST fail", async () => {
         const res = await request(server)
-            .post("/api/predict/price/234")
+            .post("/api/predict/234")
         expect(res.status).toBe(404);
     })
 
     it("Returns in JSON format", async () => {
         const res = await request(server)
-        .post("/api/predict/price/1")
+        .post("/api/predict/1")
         expect(res.type).toBe("application/json");
     })
 })


### PR DESCRIPTION
# Description

The Data Science team has created a `/predict` endpoint that returns everything. This pull request adds a matching endpoint for backend.